### PR TITLE
fix(ci/cd): use github pat for the checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The checkout action persists it throughout the remaining GitHub Action steps and we need to ensure that it's persisted with this specific token so that the release goes through as expected without running into branch protection issues