### PR TITLE
chore(ci/cd): [skip ci] fetch full git history for release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This allows lerna to see older git commits which it uses to generate changelogs